### PR TITLE
chore: extend centralized renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,10 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended",
+    "github>pl4nty/.github",
     ":disableRateLimiting"
   ],
-  "osvVulnerabilityAlerts": true,
   "dependencyDashboardOSVVulnerabilitySummary": "all",
   "additionalBranchPrefix": "{{parentDir}}-",
   "ignorePaths": [


### PR DESCRIPTION
Swaps `config:recommended` for the centralized preset `github>pl4nty/.github` (`config:best-practices` + `schedule:weekends` + 7-day `minimumReleaseAge` + OSV vulnerability alerts) and drops the now-redundant `osvVulnerabilityAlerts: true` (set centrally). `:disableRateLimiting` and all other repo-specific settings are kept.

Notes: best-practices enables digest pinning, so expect a round of pin PRs after merge. The central weekend schedule and 7-day release age will also slow regular updates here — vulnerability fixes remain unscheduled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EsPuqPb9iXJfZUD9QiRkzC

---
_Generated by [Claude Code](https://claude.ai/code/session_01EsPuqPb9iXJfZUD9QiRkzC)_