### PR TITLE
fix(web-admx-tool): bump build image to node:24-slim

### DIFF
--- a/web-admx-tool/Dockerfile
+++ b/web-admx-tool/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM node:20-slim AS build
+FROM --platform=$BUILDPLATFORM node:24-slim AS build
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 RUN corepack enable


### PR DESCRIPTION
## Problem

The `web-admx-tool` image build fails during `pnpm install --frozen-lockfile` ([failing run](https://github.com/pl4nty/containers/actions/runs/30516342282/job/90787104663)):

```
warn: This version of pnpm requires at least Node.js v22.13
warn: The current version of Node.js is v20.20.2
Error [ERR_UNKNOWN_BUILTIN_MODULE]: No such built-in module: node:sqlite
Node.js v20.20.2
ERROR: process "/bin/sh -c pnpm install --frozen-lockfile" did not complete successfully: exit code: 1
```

`web-admx-tool/package.json` pins `"packageManager": "pnpm@11.16.0"`. pnpm 11.16.0 requires **Node.js >=22.13** and imports the `node:sqlite` built-in module, neither of which exists on the `node:20-slim` base image the Dockerfile used.

## Fix

Bump the build stage base image from `node:20-slim` to `node:24-slim`, which satisfies pnpm's minimum Node version and provides the stable `node:sqlite` module.

```diff
-FROM --platform=$BUILDPLATFORM node:20-slim AS build
+FROM --platform=$BUILDPLATFORM node:24-slim AS build
```

The runtime stage (`joseluisq/static-web-server`) is unchanged.

## Verification

Docker was not available in this environment to run a full multi-platform build. The change is a direct response to the two hard errors in the build log — the pnpm minimum-version warning and the `node:sqlite` module error — both of which are resolved by moving to Node 24.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NiExxiy1xh1xYJaDBkbdV2)_