### PR TITLE
feat: flat-viewer

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -82,3 +82,6 @@
 	path = fortinet-downloads/fortinet-downloads
 	url = https://github.com/pl4nty/fortinet-downloads
 	branch = main
+[submodule "flat-viewer/flat-viewer"]
+	path = flat-viewer/flat-viewer
+	url = https://github.com/githubocto/flat-viewer

--- a/flat-viewer/Dockerfile
+++ b/flat-viewer/Dockerfile
@@ -1,0 +1,19 @@
+# vite 2 loads postcss through the "./": "./" exports mapping node dropped in 17:
+# Package subpath './lib/node' is not defined by "exports"
+FROM node:16.20.2 AS build
+WORKDIR /app
+
+COPY package.json yarn.lock ./
+RUN yarn install --frozen-lockfile --network-timeout 600000
+
+COPY . .
+RUN yarn build
+
+FROM joseluisq/static-web-server:2.44.0@sha256:2c1a7c3e0feaea5859307403b74e1c575f3ec1499094fc077344173d11abaae2
+
+COPY --from=build /app/dist /public
+
+# /:owner/:name is client-side routing, not files on disk
+ENV SERVER_FALLBACK_PAGE=/public/index.html
+ENV SERVER_PORT=8080
+EXPOSE 8080


### PR DESCRIPTION
[githubocto/flat-viewer](https://github.com/githubocto/flat-viewer) was archived on 2026-08-06, so flatgithub.com can't be relied on. Submodule + Dockerfile so it can be self-hosted; deployed by [pl4nty/homelab#1171](https://github.com/pl4nty/homelab/pull/1171).

Vite 2 loads PostCSS through the `"./": "./"` exports mapping Node removed in 17 — on anything newer the build dies with `Package subpath './lib/node' is not defined by "exports"` — so the build stage is node 16. The submodule is pinned at upstream's final commit and won't move.

Served by static-web-server on 8080 like the other static apps, with `SERVER_FALLBACK_PAGE` so the viewer's `/:owner/:name` client-side routes resolve on a cold load.

## Testing

Ran the build stage's exact steps locally on node 16 (`yarn install --frozen-lockfile && yarn build`) — `dist` builds clean. Served it behind an equivalent fallback and drove it in Chromium against `pl4nty/data`: `/pl4nty/data` resolved through the fallback and listed the repo's files and commits, and `archive/cert-oids.csv` rendered all 136 rows in the Flat grid with filters and CSV/JSON download working.

Not verified: the image itself. No container runtime was available in the session, so the static-web-server layer is unexercised until this workflow's first run.

---
_Generated by [Claude Code](https://claude.ai/code/session_018emvYSL5nt4LYAuFCsw92e)_