### PR TITLE
fix: kasm-kali python tooling without clobbering dist-packages

### DIFF
--- a/kasm-kali-rolling/Dockerfile
+++ b/kasm-kali-rolling/Dockerfile
@@ -11,7 +11,8 @@ RUN --mount=type=cache,target=/var/cache/apt \
     apt-get update && apt-get install -y --no-install-recommends \
     sudo kali-linux-default \
     libgmp3-dev libmpc-dev \
-    python3 python3-pip python3-dev git libssl-dev libffi-dev build-essential \
+    python3 python3-pip python3-venv python3-dev git libssl-dev libffi-dev build-essential \
+    python3-pwntools python3-pypykatz \
     autopsy ghidra burpsuite steghide radare2 hashcat binwalk wireshark \
     gdb gdb-peda libimage-exiftool-perl ltrace gimp audacity qsstv strace \
     gfortran qemu-system-x86 jq
@@ -22,9 +23,10 @@ RUN wget --no-hsts -q https://github.com/pwndbg/pwndbg/releases/download/2025.05
 RUN gem install zsteg
 
 # --- tooling into /opt, NOT $HOME ---
-RUN git clone --depth 1 https://github.com/RsaCtfTool/RsaCtfTool.git /opt/RsaCtfTool && \
-    pip3 install -r /opt/RsaCtfTool/requirements.txt --break-system-packages
-RUN python3 -m pip install --upgrade pwntools pypykatz --break-system-packages
+# own venv: RsaCtfTool pins old cryptography/requests/psutil, and pip can't
+# replace Kali's dist-packages anyway (dpkg ships no RECORD to uninstall from)
+RUN python3 -m venv /opt/RsaCtfTool && \
+    /opt/RsaCtfTool/bin/pip install --no-cache-dir git+https://github.com/RsaCtfTool/RsaCtfTool.git
 RUN wget --no-hsts -q http://www.caesum.com/handbook/Stegsolve.jar -O /opt/stegsolve.jar && \
     chmod 0755 /opt/stegsolve.jar
 RUN wget --no-hsts -q https://github.com/volatilityfoundation/volatility/releases/download/2.6.1/volatility_2.6_lin64_standalone.zip -O /tmp/vol.zip && \
@@ -35,7 +37,9 @@ RUN wget --no-hsts -q https://github.com/icsharpcode/AvaloniaILSpy/releases/down
     unzip -q /tmp/ilspy/ILSpy-linux-x64-Release.zip -d /opt/AvaloniaILSpy && \
     rm -rf /tmp/ilspy.zip /tmp/ilspy
 RUN ln -sf /opt/vol.py /usr/local/bin/vol.py && \
-    ln -sf /opt/RsaCtfTool/RsaCtfTool.py /usr/local/bin/RsaCtfTool.py
+    ln -sf /opt/RsaCtfTool/bin/rsacrack /usr/local/bin/rsacrack && \
+    ln -sf /opt/RsaCtfTool/bin/RsaCtfTool /usr/local/bin/RsaCtfTool && \
+    ln -sf /opt/RsaCtfTool/bin/RsaCtfTool /usr/local/bin/RsaCtfTool.py
 
 FROM base AS linux-arm64
 

--- a/kasm-kali-rolling/Dockerfile
+++ b/kasm-kali-rolling/Dockerfile
@@ -22,6 +22,8 @@ RUN wget --no-hsts -q https://github.com/pwndbg/pwndbg/releases/download/2025.05
 RUN gem install zsteg
 
 # --- tooling into /opt, NOT $HOME ---
+RUN git clone --depth 1 https://github.com/RsaCtfTool/RsaCtfTool.git /opt/RsaCtfTool && \
+    pip3 install -r /opt/RsaCtfTool/requirements.txt --break-system-packages
 RUN python3 -m pip install --upgrade pwntools pypykatz --break-system-packages
 RUN wget --no-hsts -q http://www.caesum.com/handbook/Stegsolve.jar -O /opt/stegsolve.jar && \
     chmod 0755 /opt/stegsolve.jar
@@ -32,7 +34,8 @@ RUN wget --no-hsts -q https://github.com/icsharpcode/AvaloniaILSpy/releases/down
     unzip -q /tmp/ilspy.zip -d /tmp/ilspy && \
     unzip -q /tmp/ilspy/ILSpy-linux-x64-Release.zip -d /opt/AvaloniaILSpy && \
     rm -rf /tmp/ilspy.zip /tmp/ilspy
-RUN ln -sf /opt/vol.py /usr/local/bin/vol.py
+RUN ln -sf /opt/vol.py /usr/local/bin/vol.py && \
+    ln -sf /opt/RsaCtfTool/RsaCtfTool.py /usr/local/bin/RsaCtfTool.py
 
 FROM base AS linux-arm64
 


### PR DESCRIPTION
Reverts `bdf9fe6` ("fix: kasm-kali remove rsactftool") and fixes the underlying pip failure instead.

## The failure

```
Attempting uninstall: minikerberos
  Found existing installation: minikerberos 0.4.4
error: uninstall-no-record-file

× Cannot uninstall minikerberos 0.4.4
╰─> The package's contents are unknown: no RECORD file was found for minikerberos.

hint: The package was installed by debian.
```

`kasmweb/kali-rolling-desktop` already ships `python3-pypykatz` and `python3-minikerberos` via dpkg. Debian's `.dist-info` dirs have no `RECORD`, so pip cannot uninstall them, and `pip install --upgrade pypykatz` needs a newer minikerberos than the packaged 0.4.4. `--break-system-packages` only bypasses the `EXTERNALLY-MANAGED` marker; it does not make the uninstall possible.

## The fix

**pwntools + pypykatz → apt.** Kali packages both at the same versions PyPI has (`python3-pwntools` 4.15.0, `python3-pypykatz` 0.6.13), so the pip upgrade bought nothing and only fought dpkg. `from pwn import *` still works under the system interpreter, and both stay dpkg-managed.

**RsaCtfTool → its own venv.** It is not packaged and pins `cryptography==39.0.1`, `requests==2.25.1`, `psutil==5.9.4` — installing those system-wide is the same class of breakage. It is also a real project now with `[project.scripts]`, so it installs from git directly rather than clone + `requirements.txt`; the old `RsaCtfTool.py` symlink had been dangling since the repo moved to a `src/` layout. `RsaCtfTool.py` is kept on PATH next to the new `RsaCtfTool` and `rsacrack` entry points.

## Verification

Reproduced the original error on `kalilinux/kali-rolling` with `python3-pypykatz` installed, then built the changed steps against the real `kasmweb/kali-rolling-desktop:1.19.0-rolling-weekly` base (minus `kali-linux-default`, too large to pull locally):

- build succeeds, no pip uninstall errors
- `import pwnlib` → 4.15.0, `from pwn import *` OK
- `pypykatz` CLI + `import pypykatz` OK, `pwn checksec` OK
- `RsaCtfTool`, `RsaCtfTool.py`, `rsacrack` all resolve and run
- venv isolation holds: system `cryptography` 47.0.0 / `requests` 2.32.5 vs venv 39.0.1 / 2.25.1
- `dpkg -V python3-pypykatz python3-minikerberos python3-pwntools` clean

---
_Generated by [Claude Code](https://claude.ai/code/session_017p2N6v8usUrvYuXuWoNiSG)_